### PR TITLE
Add an s to http (for the calendar link).

### DIFF
--- a/content/join.md
+++ b/content/join.md
@@ -12,7 +12,7 @@ website by creating a [pull
 request](https://github.com/Bluehats/bluehats.global) or [sending us
 an email](bluehats@bzg.fr).
 
-## 📅 Subscribe to the [public calendar](http://bluehats.global/bluehats.ics)
+## 📅 Subscribe to the [public calendar](https://bluehats.global/bluehats.ics)
 
 ## 🐘 Follow us on [fosstodon.org/@bluehats](https://fosstodon.org/@bluehats)
 


### PR DESCRIPTION
Fix a broken link (Thunderbird agenda for instance won't follow the 301header redirecting to https).